### PR TITLE
Enhance stuffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
   - php: 7.0
   - php: 7.1
   - php: 7.2
+  - php: 7.3
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A Composer ready package to start a new PHP 7 project including Composer, PHPUni
 ## Usage
 -  First install this template:
 ```
-composer require php-base-project/php-base-project
+composer create-project php-base-project/php-base-project
 ```
 - Find and replace all `php-base-project`, `PHP Base Project` and `PhpBaseProject` with your project root, name and namespace respectively.
 - Create an account on Travis, Scrutinizer and Code Climate and allow access to your repository


### PR DESCRIPTION
# Changed log

- Add `php-7.3` test in Travis CI build.
- It should use the `create-project` for package installation in `README` because this is the basic PHP project for developers to develop the modern PHP package comfortably.
The `composer` command with `require` option is about installing specific package.